### PR TITLE
remove -webkit-text-decoration-skip override

### DIFF
--- a/modules/primer-base/lib/normalize.scss
+++ b/modules/primer-base/lib/normalize.scss
@@ -89,13 +89,11 @@ template, /* 1 */
    ========================================================================== */
 
 /**
- * 1. Remove the gray background on active links in IE 10.
- * 2. Remove gaps in links underline in iOS 8+ and Safari 8+.
+ * Remove the gray background on active links in IE 10.
  */
 
 a {
   background-color: transparent; /* 1 */
-  -webkit-text-decoration-skip: objects; /* 2 */
 }
 
 /**


### PR DESCRIPTION
normalize.css [introduced](https://github.com/necolas/normalize.css/pull/573) `-webkit-text-decoration-skip: objects` for the sake of consistency. I [propose](https://github.com/necolas/normalize.css/pull/693) to revert it, because:

1. It breaks iOS and macOS platform conventions: underlines are always drawn with “ink” style in native text views.
2. It’s a step back for web typography. Apple intentionally set the browser default to “ink” to make underlined text more readable.
3. The lack of this rule doesn’t affect other browsers, but its presence is harmful.

@broccolini [mentioned](https://twitter.com/broccolini/status/896738240740433920) that GitHub uses a fork of normalize.css. I originaly noticed the issue on GitHub, and it’s where I hope to see it reverted the most. 